### PR TITLE
Final accessibility testing changes

### DIFF
--- a/campfire/src/app/app.component.html
+++ b/campfire/src/app/app.component.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-orange">
-  <a class="navbar-brand" href=""><img alt="campfire logo" src="../../assets/campfire_logo.png" height="60"></a>
+  <h1><a class="navbar-brand" href=""><img alt="campfire logo" src="../../assets/campfire_logo.png" height="60"></a></h1>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/campfire/src/app/create-event/event-basics/event-basics.component.html
+++ b/campfire/src/app/create-event/event-basics/event-basics.component.html
@@ -25,36 +25,36 @@
             <br>
             <label>Public or Private?</label>
             <div class="form-check">
-                <input class="form-check-input" type="radio" name="radioButtonPublic" id="publicButton" value="public" (click)="setPrivacy('yes')" [checked]='true' ngModel>
-                <label class="form-check-label" for="publicButton">
+                <input class="form-check-input" type="radio" name="radioButtonPublic" id="publicButton" value="public" aria-describedby="publicHelp"  (click)="setPrivacy('yes')" [checked]='true' ngModel>
+                <label class="form-check-label" for="publicButton" id="publicHelp">
                     Public
                 </label>
             </div>
             <div class="form-check">
-                <input class="form-check-input" type="radio" name="radioButtonPrivate" id="privateButton" value="private" (click)="setPrivacy('no')" ngModel>
-                <label class="form-check-label" for="privateButton">
+                <input class="form-check-input" type="radio" name="radioButtonPrivate" id="privateButton" value="private" aria-describedby="privateHelp"  (click)="setPrivacy('no')" ngModel>
+                <label class="form-check-label" for="privateButton" id="privateHelp">
                     Private
                 </label>
             </div>
             <br>
             <div class="form-group">
-                <label for="date">Date:</label>
+                <label for="datepicker" id="dateHelp">Date:</label>
                 <input type="date" name="date" class="form-control" id="datepicker" type="text" aria-describedby="dateHelp" placeholder="Enter date" ngModel>
                 <br>
-                <label for="time">Time:</label>
-                <input type="time" name="time" class="form-control" type="text" aria-describedby="timeHelp" placeholder="Enter time" ngModel>
+                <label for="time" id="timeHelp">Time:</label>
+                <input type="time" name="time" class="form-control" type="text" id="time" aria-describedby="timeHelp" placeholder="Enter time" ngModel>
             </div>
             <br>
             <label>Held online or offline?</label>
-            <div class="form-check">
-                <input class="form-check-input" type="radio" name="radioButtonOnOff" id="onlineRadio" value="online" (click)="setLine('yes')" [checked]='true' ngModel>
-                <label class="form-check-label" for="online">
+            <div class="form-check onOff">
+                <input class="form-check-input" type="radio" name="radioButtonOnOff" id="onlineRadio" value="online" aria-describedby="onlineHelp" (click)="setLine('yes')" [checked]='true' ngModel>
+                <label class="form-check-label" for="onlineRadio" id="onlineHelp">
                     Online
                 </label>
             </div>
-            <div class="form-check">
-                <input class="form-check-input" type="radio" name="radioButtonOnOff" id="offlineRadio" value="offline" (click)="setLine('no')" ngModel>
-                <label class="form-check-label" for="offlineRadio" >
+            <div class="form-check onOff">
+                <input class="form-check-input" type="radio" name="radioButtonOnOff" id="offlineRadio" value="offline" aria-describedby="offlineHelp" (click)="setLine('no')" ngModel>
+                <label class="form-check-label" for="offlineRadio" id="offlineHelp">
                     Offline
                 </label>
             </div>
@@ -64,7 +64,7 @@
     <div class="centerButton">
         <a type="button" class="bg-orange btn-step prev" routerLink='/eventStart'>&#60; Back</a>
         <a type="button" class="bg-orange btn-step next" routerLink='/eventCategories'>Next &#62;</a>
-        <h6 class="stepCompleted"> Step 2 of 4 </h6>
+        <h3 class="stepCompleted"> Step 2 of 4 </h3>
     </div>
     <div class="spacing"></div>
 </div>

--- a/campfire/src/app/create-event/event-categories/event-categories.component.html
+++ b/campfire/src/app/create-event/event-categories/event-categories.component.html
@@ -4,98 +4,98 @@
         <form #submitCategories = "ngForm" (ngSubmit) = "onClickSubmit(submitCategories.value)">
             <h2 class="form-title">Event/Club Categories</h2>
             <br />
-            <label id="eventCategories">Event Categories:</label>
-            <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="eventCategories">
+            <label for="eventCategories">Event Categories:</label>
+            <div class="btn-group-toggle categories" data-toggle="buttons" id="eventCategories">
                 <!--<label class="btn btn-orange">
                 <input type="radio" name="options" id="option1" checked> General Body Meeting (GBM)
             </label>-->
-                <label for="gbm" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="gbm" type="radio" class="btns btn-orange" autocomplete="off" value = "gbm" name="gbm" (click)="setCategory('gbm')" [checked]='true' ngModel>
+                <label for="gbmButton" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="gbmButton" type="radio" class="btns btn-orange" autocomplete="off" value = "gbm" name="gbm" (click)="setCategory('gbm')" [checked]='true' ngModel>
                     General Body Meeting (GBM)
                 </label>
-                <label for="casual" id="casual" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="casual" type="radio" class="btns btn-orange btn-category" autocomplete="off" name="casual" (click)="setCategory('casual')" ngModel>
+                <label for="casualButton" id="casual" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="casualButton" type="radio" class="btns btn-orange btn-category" autocomplete="off" name="casual" (click)="setCategory('casual')" ngModel>
                     Casual
                 </label>
-                <label for="movie" id="movie" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="movie" type="radio" class="btns btn-orange" autocomplete="off" name="movie" (click)="setCategory('movie')" ngModel>
+                <label for="movieButton" id="movie" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="movieButton" type="radio" class="btns btn-orange" autocomplete="off" name="movie" (click)="setCategory('movie')" ngModel>
                     Movie Showing
                 </label>
-                <label for="games" id="games" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="games" type="radio" class="btns btn-orange" autocomplete="off" name="games" (click)="setCategory('games')" ngModel>
+                <label for="gamesButton" id="games" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="gamesButton" type="radio" class="btns btn-orange" autocomplete="off" name="games" (click)="setCategory('games')" ngModel>
                     Games/Trivia
                 </label>
-                <label for="info" id="info" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="info" type="radio" class="btns btn-orange" autocomplete="off" name="info" (click)="setCategory('info')" ngModel>
+                <label for="infoButton" id="info" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="infoButton" type="radio" class="btns btn-orange" autocomplete="off" name="info" (click)="setCategory('info')" ngModel>
                     Informational
                 </label>
-                <label for="excursion" id="excursion" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="excursion" type="radio" class="btns btn-orange" autocomplete="off" name="excursion" (click)="setCategory('excursion')" ngModel>
+                <label for="excursionButton" id="excursion" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="excursionButton" type="radio" class="btns btn-orange" autocomplete="off" name="excursion" (click)="setCategory('excursion')" ngModel>
                     Excursion
                 </label>
-                <label for="elections" id="elections" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="elections" type="radio" class="btns btn-orange" autocomplete="off" name="elections" (click)="setCategory('elections')" ngModel>
+                <label for="electionsButton" id="elections" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="electionsButton" type="radio" class="btns btn-orange" autocomplete="off" name="elections" (click)="setCategory('elections')" ngModel>
                     Elections
                 </label>
-                <label for="workshop" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="workshop" type="radio" class="btns btn-orange" autocomplete="off" name="workshop" (click)="setCategory('workshop')" ngModel>
+                <label for="workshopButton" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="workshopButton" type="radio" class="btns btn-orange" autocomplete="off" name="workshop" (click)="setCategory('workshop')" ngModel>
                     Workshop
                 </label>
-                <label for="recruit" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="recruit" type="radio" class="btns btn-orange" autocomplete="off" name="recruit" (click)="setCategory('recruit')" ngModel>
+                <label for="recruitButton" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="recruitButton" type="radio" class="btns btn-orange" autocomplete="off" name="recruit" (click)="setCategory('recruit')" ngModel>
                     Recruiting (Company)
                 </label>
-                <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="other" type="radio" class="btns btn-orange" autocomplete="off" name="other" (click)="setCategory('other')" ngModel>
+                <label for="otherEventButton" id="otherEvent" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="otherEventButton" type="radio" class="btns btn-orange" autocomplete="off" name="other" (click)="setCategory('other')" ngModel>
                     Other
                 </label>
             </div>
             <br />
             <div class="form-group">
-                <label for="comment">Event Description:</label>
-                <textarea class="form-control" name="eventDescription" rows="2" id="description"
+                <label for="eventDescription">Event Description:</label>
+                <textarea class="form-control" name="eventDescription" rows="2" id="eventDescription"
                     placeholder="Please enter an event description." ngModel></textarea>
             </div>
             <br />
-            <label id="clubCategories">Club/Organization Categories:</label>
-            <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="clubCategories">
-                <label for="academicProf" id="academicProf" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="academicProf" type="radio" class="btns btn-orange" autocomplete="off" name="academicProf" (click)="setClub('academicProf')" [checked]='true' ngModel>
+            <label for="clubCategories">Club/Organization Categories:</label>
+            <div class="btn-group-toggle categories" data-toggle="buttons" id="clubCategories">
+                <label for="academicProfButton" id="academicProf" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="academicProfButton" type="radio" class="btns btn-orange" autocomplete="off" name="academicProf" (click)="setClub('academicProf')" [checked]='true' ngModel>
                     Academic & Professional
                 </label>
-                <label for="identity" id="identity" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="identity" type="radio" class="btns btn-orange" autocomplete="off" name="identity" (click)="setClub('identity')" ngModel>
+                <label for="identityButton" id="identity" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="identityButton" type="radio" class="btns btn-orange" autocomplete="off" name="identity" (click)="setClub('identity')" ngModel>
                     Identity Based
                 </label>
-                <label for="hobby" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="hobby" type="radio" class="btns btn-orange" autocomplete="off" name="hobby" (click)="setClub('hobby')" ngModel>
+                <label for="hobbyButton" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="hobbyButton" type="radio" class="btns btn-orange" autocomplete="off" name="hobby" (click)="setClub('hobby')" ngModel>
                     Hobby & Special Interest
                 </label>
-                <label for="service" id="service" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="service" type="radio" class="btns btn-orange" autocomplete="off" name="service" (click)="setClub('service')" ngModel>
+                <label for="serviceButton" id="service" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="serviceButton" type="radio" class="btns btn-orange" autocomplete="off" name="service" (click)="setClub('service')" ngModel>
                     Community Service
                 </label>
-                <label for="greek" id="greek" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="greek" type="radio" class="btns btn-orange" autocomplete="off" name="greek" (click)="setClub('greek')" ngModel>
+                <label for="greekButton" id="greek" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="greekButton" type="radio" class="btns btn-orange" autocomplete="off" name="greek" (click)="setClub('greek')" ngModel>
                     Greek Organization
                 </label>
-                <label for="sportsRec " id="sportsRec" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="sportsRec" type="radio" class="btns btn-orange" autocomplete="off" name="sportsRec" (click)="setClub('sportsRec')" ngModel>
+                <label for="sportsRecButton" id="sportsRec" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="sportsRecButton" type="radio" class="btns btn-orange" autocomplete="off" name="sportsRec" (click)="setClub('sportsRec')" ngModel>
                     Sports & Recreation
                 </label>
-                <label for="stuGov" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="stuGov" type="radio" class="btns btn-orange" autocomplete="off" name="stuGov" (click)="setClub('stuGov')" ngModel>
+                <label for="stuGovButton" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="stuGovButton" type="radio" class="btns btn-orange" autocomplete="off" name="stuGov" (click)="setClub('stuGov')" ngModel>
                     Student Government & Event Planning
                 </label>
-                <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                    <input id="other" type="radio" class="btns btn-orange" autocomplete="off" name="other" (click)="setClub('other')" ngModel>
+                <label for="otherClubButton" id="otherClub" class="btn btn-secondary btns btn-orange btn-category">
+                    <input id="otherClubButton" type="radio" class="btns btn-orange" autocomplete="off" name="other" (click)="setClub('other')" ngModel>
                     Other
                 </label>
             </div>
             <br />
             <div class="form-group">
-                <label for="comment">Club/Organization Description:</label>
-                <textarea class="form-control" name="clubDescription" rows="2" id="club-org"
+                <label for="clubDescription">Club/Organization Description:</label>
+                <textarea class="form-control"  name="clubDescription" rows="2" id="clubDescription"
                     placeholder="Please enter an club/organization description." ngModel></textarea>
             </div>
             <input class="btn-save" type="submit" value="Save" />
@@ -107,7 +107,7 @@
             &#60; Back
         </a>
         <a type="button" class="bg-orange btn-step next" routerLink="/eventTransportation">Next &#62;</a>
-        <h6 class="stepCompleted">Step 3 of 4</h6>
+        <h3 class="stepCompleted">Step 3 of 4</h3>
     </div>
     <div class="spacing"></div>
 </div>

--- a/campfire/src/app/create-event/event-start/event-start.component.html
+++ b/campfire/src/app/create-event/event-start/event-start.component.html
@@ -4,24 +4,24 @@
     <form #eventStart = "ngForm" (ngSubmit) = "onClickSubmit(eventStart.value)">
       <h2 class="form-title">Create New Event</h2>
       <div class="form-group">
-        <label for="emailAddress">Email address:</label>
-        <input type="email" name="yourEmailAddress" class="form-control" id="emailAddress" aria-describedby="emailHelp"
-          placeholder="Enter email" ngModel>
+        <label for="yourEmailAddress" id="emailHelp">Email address:</label>
+        <input type="email" name="yourEmailAddress" class="form-control" id="yourEmailAddress" title="Enter your Email Address" 
+        aria-describedby="emailHelp" placeholder="Enter your email" ngModel>
       </div>
       <div class="form-group">
-        <label for="eventName">Event Name:</label>
+        <label for="eventName" id="eventHelp">Event Name:</label>
         <input type="event" name="eventName" class="form-control" id="eventName" aria-describedby="eventHelp"
-          placeholder="Enter Event Name" ngModel>
+          placeholder="Enter event name" ngModel>
       </div>
       <div class="form-group">
-        <label for="yourName">Your Name (will be displayed as event owner):</label>
+        <label for="yourName" id="yourNameHelp">Your Name (will be displayed as event owner):</label>
         <input type="name" name="yourName" class="form-control" id="yourName" aria-describedby="yourNameHelp"
-          placeholder="Enter Name" ngModel>
+          placeholder="Enter club name" ngModel>
       </div>
       <div class="form-group" id="addFriends">
-        <label for="addFriend">Invite friends (email address):</label>
-        <input type="friend" name="inviteFriends" class="form-control aFriend" id="addFriend1"
-          aria-describedby="friendHelp" placeholder="Enter Email" ngModel>
+        <label for="inviteFriends" id="friendHelp">Invite friends (enter email address):</label>
+        <input type="friend" name="inviteFriends" class="form-control aFriend" title="Friend Email Address" id="inviteFriends"
+        aria-describedby="friendHelp" placeholder="Enter friend email" ngModel>
       </div>
       <a type="button" id="addFriendButton" class="bg-add-form btn-add-form"> + Add Friends </a>
       <br>
@@ -31,7 +31,7 @@
 
   <div class="centerButton">
     <a type="button" class="bg-orange btn-step next" routerLink='/eventBasics'>Next &#62;</a>
-    <h6 class="stepCompleted"> Step 1 of 4 </h6>
+    <h3 class="stepCompleted"> Step 1 of 4 </h3>
   </div>
   <div class="spacing"></div>
 </div>

--- a/campfire/src/app/create-event/event-transportation/event-transportation.component.html
+++ b/campfire/src/app/create-event/event-transportation/event-transportation.component.html
@@ -4,8 +4,8 @@
             <h2 class="form-title">Event Activities and Transportation</h2>
             <br>
             <div class="form-group">
-                <label for="yourName">Spotify Playlist link:</label>
-                <input type="name" name="spotifyPlaylist" class="form-control" id="yourName" aria-describedby="yourNameHelp"
+                <label for="spotifyPlaylist" id="playlistHelp">Spotify Playlist link:</label>
+                <input type="playlist" name="spotifyPlaylist" class="form-control" id="spotifyPlaylist" aria-describedby="playlistHelp"
                   placeholder="Enter Spotify playlist URL" ngModel>
               </div>
             <label>Does your event require transportation?</label>
@@ -23,8 +23,8 @@
             </div>
             <br>
             <div class="form-group" id="addCars">
-                <label for="addCar">If so, add cars:</label>
-                <input type="car" class="form-control aCar" name="driverName" id="addCar1" aria-describedby="carHelp"
+                <label for="addCar" id="carHelp">If so, add cars:</label>
+                <input type="car" class="form-control aCar" name="driverName" id="addCar" aria-describedby="carHelp"
                     placeholder="Enter name of driver" ngModel>
             </div>
             <a type="button" id="addCarButton" class="bg-add-form btn-add-form"> + Add Car </a>
@@ -36,7 +36,7 @@
     <div class="centerButton">
         <a type="button" class="bg-orange btn-step prev" routerLink='/eventCategories'> &#60; Back </a>
         <a type="button" class="bg-orange btn-step next" routerLink='/finish'>Next &#62;</a>
-        <h6 class="stepCompleted"> Step 4 of 4 </h6>
+        <h3 class="stepCompleted"> Step 4 of 4 </h3>
     </div>
     <div class="spacing"></div>
 </div>

--- a/campfire/src/app/create-event/finish/finish.component.html
+++ b/campfire/src/app/create-event/finish/finish.component.html
@@ -5,7 +5,7 @@
     <form #submitEventCode = "ngForm" (ngSubmit) = "onClickSubmit(submitEventCode.value)">
         <div class="row">
             <div class="column5">
-                <img class="peopleCelebrate" src="../../assets/celebrate.svg" width="100%">
+                <img class="peopleCelebrate" src="../../assets/celebrate.svg" width="100%" alt="Animated illustration of people jumping in the air holding streamers, with fireworks in the background.">
             </div>
             <div class="column6">
                 <h2 id="text"> You’re all set! </h2>

--- a/campfire/src/app/dashboard/owner-dashboard/owner-dashboard.component.css
+++ b/campfire/src/app/dashboard/owner-dashboard/owner-dashboard.component.css
@@ -35,10 +35,11 @@
     top: 10px;
     right: 15px;
   }
-  h4.panel-title{
+  h3.panel-title{
     background-color: #C32E09;
     color: white;
     height: 50px;
+    font-size: x-large;
     border-radius: 10px;
     margin-right: 2%;
     margin-left: 2%;

--- a/campfire/src/app/dashboard/owner-dashboard/owner-dashboard.component.html
+++ b/campfire/src/app/dashboard/owner-dashboard/owner-dashboard.component.html
@@ -30,18 +30,18 @@
         </div>
     </div>
     <h1 class="form-center">Web Sci Demo</h1>
-    <h3 class="form-center">Team Campfire</h3>
+    <h2 class="form-center">Team Campfire</h2>
     <!-- <input class="form-center" class="form-control" type="text" [value]="eventName"> -->
-    <div id="accordion">
+    <div id="allAccordions">
         <div class="panel-group" id="accordion">
 
             <!-- First Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseBasics">Basics</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseBasics">Basics</h3>
                 </div>
 
-                <div id="collapseBasics" class="panel-collapse collapse">
+                <div id="collapseBasics" class="panel-collapse collapse" title="Event Basics">
                     <div class="panel-body">
                         <div class="row">
                             <div class="column7">
@@ -62,38 +62,44 @@
                                     </label>
                                 </div><br>
                                 <div class="form-group">
-                                    <label for="date">Date:</label>
+                                    <label for="datepicker" id="dateHelp">Date:</label>
                                     <input type="date" class="form-control" id="datepicker" type="text" [value]="date" aria-describedby="dateHelp">
                                     <br>
-                                    <label for="time">Time:</label>
-                                    <input type="time" class="form-control" type="text" aria-describedby="timeHelp" [value]="time">
+                                    <label for="time" id="timeHelp">Time:</label>
+                                    <input id="time" type="time" class="form-control" type="text" aria-describedby="timeHelp" [value]="time">
                                     <!--<h5 for="date">Date:</h5>
                                     <input type="event" class="form-control" id="datepicker" type="text"
                                         aria-describedby="dateHelp" placeholder="Enter Date" [value]="date">-->
                                 </div>
-                                <div class="calendar">
+                                <br>
+                                <label for="calendar">Google Calendar:</label>
+                                <div id="calendar" class="calendar" role="presentation">
                                     <iframe
                                         src="https://calendar.google.com/calendar/embed?src=teamcampfire21%40gmail.com&ctz=America%2FNew_York"
                                         style="border: 0" width="100%" height="400px" frameborder="0"
-                                        scrolling="no"></iframe>
+                                        scrolling="yes" title="Google Calendar" role="presentation"></iframe>
                                 </div>
                             </div>
                             <div class="column8">
                                 <br>
                                 <h4>Location:</h4>
                                 <div class="form-group">
-                                    <h5 for="date">In-Person:</h5>
-                                    <input type="event" class="form-control" id="In-Person" aria-describedby="dateHelp"
+                                    <h5 for="In-Person">In-Person:</h5>
+                                    <input type="event" class="form-control" id="In-Person"
                                         placeholder="Enter Event Address" [value]="addy">
                                     <br>
-                                    <h5 for="date">Virtual:</h5>
-                                    <input type="event" class="form-control" id="virtual" aria-describedby="dateHelp"
+                                    <h5 for="virtual">Virtual:</h5>
+                                    <input type="event" class="form-control" id="virtual"
                                         placeholder="Enter Virtual Link" [value]="oaddy">
+                                    <br>
+                                    <br>
+                                    <br>
+                                    <label for="googleMaps">Google Maps:</label>
                                     <br>
                                     <iframe
                                         src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2930.7698036395595!2d-73.68107708522975!3d42.72976277916387!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89de0f9eebfa097d%3A0xa5592b13db1f5302!2sRensselaer%20Polytechnic%20Institute!5e0!3m2!1sen!2sus!4v1615488659473!5m2!1sen!2sus"
                                         width="100%" height="385px" style="border:0;" allowfullscreen=""
-                                        loading="lazy"></iframe>
+                                        loading="lazy" title="Google Maps of event location" alt="Google Maps of event location (if in person, otherwise shows RPI)"  role="presentation"></iframe>
                                 </div>
                             </div>
                         </div>
@@ -103,108 +109,108 @@
             <!-- Second Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseCategories"> Categories</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseCategories"> Categories</h3>
                 </div>
                 <div id="collapseCategories" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <label id="eventCategories">Event Categories:</label>
+                        <label for="eventCategories">Event Categories:</label>
                         <div class="btn-group-toggle categories" data-toggle="buttons"
-                            aria-labelledby="eventCategories">
+                            id="eventCategories">
                             <!--<label class="btn btn-orange">
                                 <input type="radio" name="options" id="option1" checked> General Body Meeting (GBM)
                             </label>-->
-                            <label for="gbm" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="gbm" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="gbmButton" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="gbmButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 General Body Meeting (GBM)
                             </label>
-                            <label for="casual" id="casual" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="casual" type="radio" class="btns btn-orange btn-category"
+                            <label for="casualButton" id="casual" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="casualButton" type="radio" class="btns btn-orange btn-category"
                                     autocomplete="off" />
                                 Casual
                             </label>
-                            <label for="movie" id="movie" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="movie" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="movieButton" id="movie" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="movieButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Movie Showing
                             </label>
-                            <label for="games" id="games" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="games" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="gamesButton" id="games" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="gamesButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Games/Trivia
                             </label>
-                            <label for="info" id="info" class="btn btn-secondary btns btn-orange btn-category active">
-                                <input id="info" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="infoButton" id="info" class="btn btn-secondary btns btn-orange btn-category active">
+                                <input id="infoButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Informational
                             </label>
-                            <label for="excursion" id="excursion"
+                            <label for="excursionButton" id="excursion"
                                 class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="excursion" type="radio" class="btns btn-orange" autocomplete="off" />
+                                <input id="excursionButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Excursion
                             </label>
-                            <label for="elections" id="elections"
+                            <label for="electionsButton" id="elections"
                                 class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="elections" type="radio" class="btns btn-orange" autocomplete="off" />
+                                <input id="electionsButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Elections
                             </label>
-                            <label for="workshop" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="workshop" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="workshopButton" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="workshopButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Workshop
                             </label>
-                            <label for="recruit" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="recruit" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="recruitButton" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="recruitButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Recruiting (Company)
                             </label>
-                            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="other" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="otherEventButton" id="otherEvent" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="otherEventButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Other
                             </label>
                         </div>
                         <br />
                         <div class="form-group">
-                            <label for="comment">Event Description:</label>
-                            <textarea class="form-control" name="eventDescription" rows="2" id="description"
+                            <label for="eventDescription">Event Description:</label>
+                            <textarea class="form-control" name="eventDescription" rows="2" id="eventDescription"
                                 placeholder="Please enter an event description." [value]="eventDesc"></textarea>
                         </div>
                         <br />
-                        <label id="clubCategories">Club/Organization Categories:</label>
-                        <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="clubCategories">
-                            <label for="academicProf" id="academicProf"
+                        <label for="clubCategories">Club/Organization Categories:</label>
+                        <div class="btn-group-toggle categories" data-toggle="buttons" id="clubCategories">
+                            <label for="academicProfButton" id="academicProf"
                                 class="btn btn-secondary btns btn-orange btn-category active">
-                                <input id="academicProf" type="radio" class="btns btn-orange" autocomplete="off" />
+                                <input id="academicProfButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Academic & Professional
                             </label>
-                            <label for="identity" id="identity" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="identity" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="identityButton" id="identity" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="identityButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Identity Based
                             </label>
-                            <label for="hobby" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="hobby" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="hobbyButton" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="hobbyButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Hobby & Special Interest
                             </label>
-                            <label for="service" id="service" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="service" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="serviceButton" id="service" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="serviceButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Community Service
                             </label>
-                            <label for="greek" id="greek" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="greek" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="greekButton" id="greek" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="greekButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Greek Organization
                             </label>
-                            <label for="sportsRec " id="sportsRec"
+                            <label for="sportsRecButton" id="sportsRec"
                                 class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="sportsRec" type="radio" class="btns btn-orange" autocomplete="off" />
+                                <input id="sportsRecButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Sports & Recreation
                             </label>
-                            <label for="stuGov" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="stuGov" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="stuGovButton" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="stuGovButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Student Government & Event Planning
                             </label>
-                            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                                <input id="other" type="radio" class="btns btn-orange" autocomplete="off" />
+                            <label for="otherButton" id="other" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="otherButton" type="radio" class="btns btn-orange" autocomplete="off" />
                                 Other
                             </label>
                         </div>
                         <br />
                         <div class="form-group">
-                            <label for="comment">Club/Organization Description:</label>
-                            <textarea class="form-control" name="clubDescription" rows="2" id="club-org"
+                            <label for="clubDescription">Club/Organization Description:</label>
+                            <textarea class="form-control" name="clubDescription" rows="2" id="clubDescription"
                                 placeholder="Please enter an club/organization description."
                                 [value]="clubOrgDesc"></textarea>
                         </div>
@@ -214,31 +220,31 @@
             <!-- Third Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseActivities">Activities</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseActivities">Activities</h3>
                 </div>
                 <div id="collapseActivities" class="panel-collapse collapse">
                     <div class="panel-body">
                         <h4>Planned Activities:</h4>
                         <br>
                         <!-- <div class="container"> -->
-                        <table id="myTable" class=" table order-list">
+                        <table id="activitiesTable" class=" table order-list">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Activity</td>
-                                    <td>Assignee</td>
+                                    <td id="activityNumberHelp" >Number</td>
+                                    <td id="activityHelp">Activity</td>
+                                    <td id="activityAssigneeHelp"> ssignee</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="number" class="form-control" />
+                                        <input type="text" name="number" class="form-control" aria-labelledby="activityNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="activity" class="form-control" />
+                                        <input type="text" name="activity" class="form-control" aria-labelledby="activityHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="assignee" class="form-control" />
+                                        <input type="text" name="assignee" class="form-control" aria-labelledby="activityAssigneeHelp" />
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -262,24 +268,24 @@
                         <h4>Delegate Tasks:</h4>
                         <br>
                         <!-- <div class="container"> -->
-                        <table id="myTable" class=" table order-list-tasks">
+                        <table id="tasksTable" class=" table order-list-tasks">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Task</td>
-                                    <td>Assignee</td>
+                                    <td id="taskNumberHelp">Number</td>
+                                    <td id="taskHelp">Task</td>
+                                    <td id="taskAssigneeHelp">Assignee</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="num" class="form-control" />
+                                        <input type="text" name="num" class="form-control" aria-labelledby="taskNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="task" class="form-control" />
+                                        <input type="text" name="task" class="form-control" aria-labelledby="taskHelp" />
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="assignees" class="form-control" />
+                                        <input type="text" name="assignees" class="form-control" aria-labelledby="taskAssigneeHelp" />
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -298,10 +304,10 @@
                         </table>
                         <!-- <a type="button" class="bg-add btn-add" href=""> + Add Tasks </a> -->
                         <br>
-                        <h4>Spotify Playlist:</h4>
+                        <h4 id="playlistHelp">Spotify Playlist:</h4>
                         <!-- <iframe src="https://open.spotify.com/embed/playlist/7qV4iT5K3Ivk8FlokZEBR9" width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe> -->
                         <iframe src="https://open.spotify.com/embed/playlist/6gXbIpaokqIdRKJtYlp7HO" width="100%"
-                            height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                            height="380" frameborder="0" allowtransparency="true" allow="encrypted-media" aria-describedby="playlistHelp"></iframe>
                     </div>
                 </div>
             </div>
@@ -309,31 +315,31 @@
             <!-- Fourth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseTransportation">
-                        Transportation</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseTransportation">
+                        Transportation</h3>
                 </div>
 
                 <div id="collapseTransportation" class="panel-collapse collapse">
                     <div class="panel-body">
                         <h4>Ride Arrangements:</h4>
-                        <table id="myTable" class=" table order-list-car">
+                        <table id="transportationTable" class=" table order-list-car">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Driver Name</td>
-                                    <td>Riders</td>
+                                    <td id="rideNumberHelp">Number</td>
+                                    <td id="driverHelp">Driver Name</td>
+                                    <td id="ridersHelp">Riders</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="carNum" class="form-control" />
+                                        <input type="text" name="carNum" class="form-control" aria-labelledby="rideNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="car" class="form-control" />
+                                        <input type="text" name="car" class="form-control" aria-labelledby="driverHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="driver" class="form-control" />
+                                        <input type="text" name="driver" class="form-control"  aria-labelledby="ridersHelp"/>
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -358,7 +364,7 @@
             <!-- Fifth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseNotes">Notes</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseNotes">Notes</h3>
                 </div>
 
                 <div id="collapseNotes" class="panel-collapse collapse">
@@ -381,7 +387,7 @@
             <!-- Sixth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseJoin">Join</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseJoin">Join</h3>
                 </div>
 
                 <div id="collapseJoin" class="panel-collapse collapse">

--- a/campfire/src/app/dashboard/viewer-dashboard/viewer-dashboard.component.css
+++ b/campfire/src/app/dashboard/viewer-dashboard/viewer-dashboard.component.css
@@ -35,9 +35,10 @@
   top: 10px;
   right: 15px;
 }
-h4.panel-title{
+h3.panel-title{
   background-color: #C32E09;
   color:white;
+  font-size: x-large;
   height: 50px;
   border-radius: 10px;
   margin-right: 2%;

--- a/campfire/src/app/dashboard/viewer-dashboard/viewer-dashboard.component.html
+++ b/campfire/src/app/dashboard/viewer-dashboard/viewer-dashboard.component.html
@@ -30,19 +30,19 @@
         </div>
     </div>
     <h1 class="form-center">Web Sci Demo</h1>
-    <h3 class="form-center">Team Campfire</h3>
+    <h2 class="form-center">Team Campfire</h2>
     <!-- <input class="form-center" class="form-control" type="text" [value]="eventName" readonly> -->
-    <div id="accordion">
+    <div id="allAccordions">
         <div class="panel-group" id="accordion">
 
              <!--First Panel-->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseBasics">Basics</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseBasics">Basics</h3>
                 </div>
 
                 <div id="collapseBasics" class="panel-collapse collapse">
-                    <div class="panel-body">
+                    <div class="panel-body" title="Event Basics">
                         <div class="row">
                             <div class="column7">
                                 <!-- <input type="button" (click)="fillForm()" id="coolbutton"> -->
@@ -62,37 +62,43 @@
                                     </label>
                                 </div><br>
                                 <div class="form-check">
-                                    <label for="date">Date:</label>
+                                    <label for="datepicker" id="dateHelp">Date:</label>
                                     <input type="date" class="form-control" id="datepicker" type="text" [value]="date" aria-describedby="dateHelp"
                                         readonly>
                                     <br>
-                                    <label for="time">Time:</label>
-                                    <input type="time" class="form-control" type="text" aria-describedby="timeHelp"
+                                    <label for="time" id="timeHelp">Time:</label>
+                                    <input type="time" id="time" class="form-control" type="text" aria-describedby="timeHelp"
                                     [value]="time" readonly>
                                 </div>
-                                <div class="calendar">
+                                <br>
+                                <label for="calendar">Google Calendar:</label>
+                                <div id="calendar" class="calendar" role="presentation">
                                     <iframe
                                         src="https://calendar.google.com/calendar/embed?src=teamcampfire21%40gmail.com&ctz=America%2FNew_York"
                                         style="border: 0" width="100%" height="400px" frameborder="0"
-                                        scrolling="no"></iframe>
+                                        scrolling="yes" title="Google Calendar" role="presentation"></iframe>
                                 </div>
                             </div>
                             <div class="column8">
                                 <br>
                                 <h4>Location:</h4>
                                 <div class="form-group">
-                                    <h5 for="date">In-Person:</h5>
-                                    <input type="event" class="form-control" id="In-Person" aria-describedby="dateHelp"
+                                    <h5 for="In-Person">In-Person:</h5>
+                                    <input type="event" class="form-control" id="In-Person"
                                         placeholder="Enter Event Address" [value]="addy" readonly>
                                     <br>
-                                    <h5 for="date">Virtual:</h5>
-                                    <input type="event" class="form-control" id="virtual" aria-describedby="dateHelp"
+                                    <h5 for="virtual">Virtual:</h5>
+                                    <input type="event" class="form-control" id="virtual" 
                                         placeholder="Enter Virtual Link" [value]="oaddy" readonly>
                                     <br>
-                                    <iframe
+                                    <br>
+                                    <br>
+                                    <label for="googleMaps">Google Maps:</label>
+                                    <br>
+                                    <iframe id="googleMaps"
                                         src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2930.7698036395595!2d-73.68107708522975!3d42.72976277916387!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89de0f9eebfa097d%3A0xa5592b13db1f5302!2sRensselaer%20Polytechnic%20Institute!5e0!3m2!1sen!2sus!4v1615488659473!5m2!1sen!2sus"
                                         width="100%" height="385px" style="border:0;" allowfullscreen=""
-                                        loading="lazy"></iframe>
+                                        loading="lazy" title="Google Maps of event location" alt="Google Maps of event location (if in person, otherwise shows RPI)"  role="presentation"></iframe>
                                 </div>
                             </div>
                         </div>
@@ -102,108 +108,108 @@
             <!-- Second Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseCategories"> Categories</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseCategories"> Categories</h3>
                 </div>
                 <div id="collapseCategories" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <label id="eventCategories">Event Categories:</label>
+                        <label for="eventCategories">Event Categories:</label>
                         <div class="btn-group-toggle categories" data-toggle="buttons"
-                            aria-labelledby="eventCategories">
+                            id="eventCategories">
                             <!--<label class="btn btn-orange">
                                 <input type="radio" name="options" id="option1" checked> General Body Meeting (GBM)
                             </label>-->
-                            <label for="gbm" id="gbm" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="gbm" type="radio" class="btns btn-orange" autocomplete="off" disabled> General Body Meetings (GBM)
+                            <label for="gbmButton" id="gbm" class="btn btn-secondary btns btn-orange btn-category"> 
+                                <input id="gbmButton" type="radio" class="btns btn-orange disabled" autocomplete="off" disabled aria-disabled="true"> General Body Meetings (GBM)
                               </label>
-                            <label for="casual" id="casual" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="casual" type="radio" class="btns btn-orange btn-category"
-                                    autocomplete="off" disabled>
+                            <label for="casualButton" id="casual" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="casualButton" type="radio" class="btns btn-orange btn-category"
+                                    autocomplete="off">
                                 Casual
                             </label>
-                            <label for="movie" id="movie" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="movie" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="movieButton" id="movie" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="movieButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Movie Showing
                             </label>
-                            <label for="games" id="games" class="btn btn-secondary btns btn-orange btn-category " disabled>
-                                <input id="games" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="gamesButton" id="games" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="gamesButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Games/Trivia
                             </label>
-                            <label for="info" id="info" class="btn btn-secondary btns btn-orange btn-category active">
-                                <input id="info" type="radio" class="btns btn-orange " autocomplete="off" >
+                            <label for="infoButton" id="info" class="btn btn-secondary btns btn-orange btn-category active current">
+                                <input id="infoButton" type="radio" class="btns btn-orange " autocomplete="off" checked disabled>
                                 Informational
                             </label>
-                            <label for="excursion" id="excursion"
-                                class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="excursion" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="excursionButton" id="excursion"
+                                class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="excursionButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Excursion
                             </label>
-                            <label for="elections" id="elections"
-                                class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="elections" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="electionsButton" id="elections"
+                                class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="electionsButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Elections
                             </label>
-                            <label for="workshop" id="workshop" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="workshop" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="workshopButton" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="workshopButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Workshop
                             </label>
-                            <label for="recruit" id="recruit" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="recruit" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="recruitButton" id="recruit" class="btn btn-secondary btns btn-orange btn-category" >
+                                <input id="recruitButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Recruiting (Company)
                             </label>
-                            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category"disabled >
-                                <input id="other" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="otherEventButton" id="otherEvent" class="btn btn-secondary btns btn-orange btn-category" >
+                                <input id="otherEventButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Other
                             </label>
                         </div>
                         <br />
                         <div class="form-group">
-                            <label for="comment">Event Description:</label>
-                            <textarea class="form-control" name="eventDescription" rows="2" id="description"
+                            <label for="eventDescription">Event Description:</label>
+                            <textarea class="form-control" name="eventDescription" rows="2" id="eventDescription"
                                 placeholder="Please enter an event description." [value]="eventDesc"
                                 readonly></textarea>
                         </div>
                         <br />
-                        <label id="clubCategories">Club/Organization Categories:</label>
-                        <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="clubCategories">
-                            <label for="academicProf" id="academicProf"
-                                class="btn btn-secondary btns btn-orange btn-category active">
-                                <input id="academicProf" type="radio" class="btns btn-orange" autocomplete="off">
+                        <label for="clubCategories">Club/Organization Categories:</label>
+                        <div class="btn-group-toggle categories" data-toggle="buttons" id="clubCategories">
+                            <label for="academicProfButton" id="academicProf"
+                                class="btn btn-secondary btns btn-orange btn-category active current">
+                                <input id="academicProfButton" type="radio" class="btns btn-orange" autocomplete="off" checked disabled aria-disabled="true">
                                 Academic & Professional
                             </label>
-                            <label for="identity" id="identity" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="identity" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="identityButton" id="identity" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="identityButton" type="radio" class="btns btn-orange" autocomplete="off" disabled>
                                 Identity Based
                             </label>
-                            <label for="hobby" id="hobby" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="hobby" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="hobbyButton" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="hobbyButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Hobby & Special Interest
                             </label>
-                            <label for="service" id="service" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="service" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="serviceButton" id="service" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="serviceButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Community Service
                             </label>
-                            <label for="greek" id="greek" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="greek" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="greekButton" id="greek" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="greekButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Greek Organization
                             </label>
-                            <label for="sportsRec " id="sportsRec"
-                                class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="sportsRec" type="radio" class="btns btn-orange" autocomplete="off" disabled>
+                            <label for="sportsRecButton" id="sportsRec"
+                                class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="sportsRecButton" type="radio" class="btns btn-orange" autocomplete="off" disabled aria-disabled="true">
                                 Sports & Recreation
                             </label>
-                            <label for="stuGov" id="stuGov" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="stuGov" type="radio" class="btns btn-orange" autocomplete="off"disabled>
+                            <label for="stuGovButton" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="stuGovButton" type="radio" class="btns btn-orange" autocomplete="off"disabled aria-disabled="true">
                                 Student Government & Event Planning
                             </label>
-                            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category" disabled>
-                                <input id="other" type="radio" class="btns btn-orange " autocomplete="off" disabled>
+                            <label for="otherClubButton" id="otherClub" class="btn btn-secondary btns btn-orange btn-category">
+                                <input id="otherClubButton" type="radio" class="btns btn-orange " autocomplete="off" disabled aria-disabled="true"> 
                                 Other
                             </label>
                         </div>
                         <br />
                         <div class="form-group">
-                            <label for="comment">Club/Organization Description:</label>
-                            <textarea class="form-control" name="clubDescription" rows="2" id="club-org"
+                            <label for="clubDescription">Club/Organization Description:</label>
+                            <textarea class="form-control" name="clubDescription" rows="2" id="clubDescription"
                                 placeholder="Please enter an club/organization description." [value]="clubOrgDesc"
                                 readonly></textarea>
                         </div>
@@ -213,31 +219,31 @@
             <!-- Third Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseActivities">Activities</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseActivities">Activities</h3>
                 </div>
                 <div id="collapseActivities" class="panel-collapse collapse">
                     <div class="panel-body">
                         <h4>Planned Activities:</h4>
                         <br>
                         <!-- <div class="container"> -->
-                        <table id="myTable" class=" table order-list">
+                        <table id="activitiesTable" class=" table order-list">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Activity</td>
-                                    <td>Assignee</td>
+                                    <td id="activityNumberHelp">Number</td>
+                                    <td id="activityHelp">Activity</td>
+                                    <td id="activityAssigneeHelp">Assignee</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="number" class="form-control" />
+                                        <input type="text" name="number" class="form-control" aria-labelledby="activityNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="activity" class="form-control" />
+                                        <input type="text" name="activity" class="form-control" aria-labelledby="activityHelp" />
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="assignee" class="form-control" />
+                                        <input type="text" name="assignee" class="form-control" aria-labelledby="activityAssigneeHelp" />
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -261,24 +267,24 @@
                         <h4>Delagate Tasks:</h4>
                         <br>
                         <!-- <div class="container"> -->
-                        <table id="myTable" class=" table order-list-tasks">
+                        <table id="tasksTable" class=" table order-list-tasks">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Task</td>
-                                    <td>Assignee</td>
+                                    <td id="taskNumberHelp">Number</td>
+                                    <td id="taskHelp">Task</td>
+                                    <td id="taskAssigneeHelp">Assignee</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="num" class="form-control" />
+                                        <input type="text" name="num" class="form-control" aria-labelledby="taskNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="task" class="form-control" />
+                                        <input type="text" name="task" class="form-control" aria-labelledby="taskHelp" />
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="assignees" class="form-control" />
+                                        <input type="text" name="assignees" class="form-control" aria-labelledby="taskAssigneeHelp"/>
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -297,10 +303,10 @@
                         </table>
                         <!-- <a type="button" class="bg-add btn-add" href=""> + Add Tasks </a> -->
                         <br>
-                        <h4>Spotify Playlist:</h4>
+                        <h4 id="playlistHelp">Spotify Playlist:</h4>
                         <!-- <iframe src="https://open.spotify.com/embed/playlist/7qV4iT5K3Ivk8FlokZEBR9" width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe> -->
                         <iframe src="https://open.spotify.com/embed/playlist/6gXbIpaokqIdRKJtYlp7HO" width="100%"
-                            height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                            height="380" frameborder="0" allowtransparency="true" allow="encrypted-media" title="Spotify playlist" aria-describedby="playlistHelp"></iframe>
                     </div>
                 </div>
             </div>
@@ -308,31 +314,31 @@
             <!-- Fourth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseTransportation">
-                        Transportation</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseTransportation">
+                        Transportation</h3>
                 </div>
 
                 <div id="collapseTransportation" class="panel-collapse collapse">
                     <div class="panel-body">
                         <h4>Ride Arrangements:</h4>
-                        <table id="myTable" class=" table order-list-car">
+                        <table id="transportationTable" class=" table order-list-car">
                             <thead>
                                 <tr>
-                                    <td>Number</td>
-                                    <td>Driver Name</td>
-                                    <td>Riders</td>
+                                    <td id="rideNumberHelp">Number</td>
+                                    <td id="driverHelp">Driver Name</td>
+                                    <td id="ridersHelp">Riders</td>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td class="col-sm-4" style="width: 10%;">
-                                        <input type="text" name="carNum" class="form-control" />
+                                        <input type="text" name="carNum" class="form-control" aria-labelledby="rideNumberHelp"/>
                                     </td>
                                     <td class="col-sm-4" style="width: 25%;">
-                                        <input type="text" name="car" class="form-control" />
+                                        <input type="text" name="car" class="form-control" aria-labelledby="driverHelp" />
                                     </td>
                                     <td class="col-sm-4" style="width: 65%;">
-                                        <input type="text" name="driver" class="form-control" />
+                                        <input type="text" name="driver" class="form-control" aria-labelledby="ridersHelp"/>
                                     </td>
                                     <td class="col-sm-2"><a class="deleteRow"></a>
 
@@ -357,7 +363,7 @@
             <!-- Fifth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseNotes">Notes</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseNotes">Notes</h3>
                 </div>
 
                 <div id="collapseNotes" class="panel-collapse collapse">
@@ -380,7 +386,7 @@
             <!-- Sixth Panel -->
             <div class="panel panel-default">
                 <div class="panel-heading panel-heading-full">
-                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseJoin">Join</h4>
+                    <h3 class="panel-title" data-toggle="collapse" data-target="#collapseJoin">Join</h3>
                 </div>
 
                 <div id="collapseJoin" class="panel-collapse collapse">

--- a/campfire/src/app/event-feed/event-feed.component.css
+++ b/campfire/src/app/event-feed/event-feed.component.css
@@ -57,7 +57,7 @@ p.num-attendees{
     display: inline;
 
 }
-h5.event-name{
+h2.event-name{
     /* font-family: Futura; */
     font-family: 'Alata', sans-serif;
     font-style: normal;

--- a/campfire/src/app/event-feed/event-feed.component.html
+++ b/campfire/src/app/event-feed/event-feed.component.html
@@ -6,7 +6,7 @@
         </button>
         <div class="collapse navbar-collapse" id="dropdownCat">
                 <div class="dropdown eventDropdown">
-                    <button id="eventDropdownBtn" onclick="eventDropdownMobile()"
+                    <button id="eventDropdownBtnMobile" onclick="eventDropdownMobile()"
                         class="btn-secondary dropdown-toggle bg-orange">Event Category <b class="caret"></b></button>
                     <!--DROPDOWN STYLE ONE: standard drop down menus, different colors for the text depending on the event.
                     Could add some icons to the left of each item's text to better clarify?-->
@@ -57,7 +57,7 @@
             
 
                 <div class="dropdown">
-                    <button id = "clubDropdownBtn" onclick="clubDropdownMobile()" class="btn-secondary dropdown-toggle bg-orange">Club Category <b
+                    <button id = "clubDropdownBtnMobile" onclick="clubDropdownMobile()" class="btn-secondary dropdown-toggle bg-orange">Club Category <b
                             class="caret"></b></button>
                     <div id="clubDropdown-mobile" class="dropdown-menu">
                         <!--DROPDOWN STYLE TWO: buttons within each dropdown menu item-->
@@ -103,12 +103,12 @@
                         <input id="casual" type="radio" class="btns btn-orange btn-category" autocomplete="off"> Casual
                     </label> -->
 
-                    <label for="online" id="online" class="btn btn-secondary btns btn-orange btn-category">
-                        <input id="online" type="radio" class="btns btn-orange" autocomplete="off" name="online" (click)="setLocation('online')" ngModel> Online
+                    <label for="online-mobile" id="onlineHelpMobile" class="btn btn-secondary btns btn-orange btn-category">
+                        <input id="online-mobile" type="radio" class="btns btn-orange" autocomplete="off" name="online-mobile" (click)="setLocation('online')" ngModel> Online
                     </label>
 
-                    <label for="online" id="online" class="btn btn-secondary btns btn-orange btn-category">
-                        <input id="offline" type="radio" class="btns btn-orange" autocomplete="off"  name="offline" (click)="setLocation('offline')" ngModel> Offline
+                    <label for="offline-mobile" id="offlineHelp-mobile" class="btn btn-secondary btns btn-orange btn-category">
+                        <input id="offline-mobile" type="radio" class="btns btn-orange" autocomplete="off"  name="offline-mobile" (click)="setLocation('offline')" ngModel> Offline
                     </label>
             
                 <!-- <button type="button" class="btns btn-orange event-category" style="width: auto;">Online</button>
@@ -211,11 +211,11 @@
                 </div>
             <div class="right-align onlineOffline btn-group-toggle categories" data-toggle="buttons">
 
-                    <label for="online" id="online" class="btn btn-secondary btns btn-orange btn-category">
+                    <label for="online" id="onlineHelp" class="btn btn-secondary btns btn-orange btn-category">
                         <input id="online" type="radio" class="btns btn-orange" autocomplete="off" name="online" (click)="setLocation('online')" ngModel> Online
                     </label>
 
-                    <label for="online" id="online" class="btn btn-secondary btns btn-orange btn-category">
+                    <label for="offline" id="offlineHelp" class="btn btn-secondary btns btn-orange btn-category">
                         <input id="offline" type="radio" class="btns btn-orange" autocomplete="off"  name="offline" (click)="setLocation('offline')" ngModel> Offline
                     </label>
             
@@ -254,7 +254,7 @@
                 alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">WED, 22 APR, 6:00 PM EDT</p>
-                <h5 class="card-title event-name">Web Sci Demo</h5>
+                <h2 class="card-title event-name">Web Sci Demo</h2>
                 <p class="card-text event-organizer">Team Campfire</p>
                 <button type="button" class="btns event-category info" style="width: auto;"
                     disabled>Informational</button>
@@ -273,7 +273,7 @@
             <img src="../../assets/finding-pana.svg" class="card-img-top" alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">THURS, 29 APR, 5:00 PM EDT</p>
-                <h5 class="card-title event-name">Finding your 'Ninth Path'</h5>
+                <h2 class="card-title event-name">Finding your 'Ninth Path'</h2>
                 <p class="card-text event-organizer">ITWS Leadership</p>
                 <button type="button" class="btns event-category gbm" style="width: auto;" disabled>General Body
                     Meetings (GBM)</button>
@@ -296,7 +296,7 @@
             <img src="../../assets/movie-pana.svg" class="card-img-top" alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">MON, 03 MAY, 6:00 PM EDT</p>
-                <h5 class="card-title event-name">Decolonizing Language: Sky Hopinka</h5>
+                <h2 class="card-title event-name">Decolonizing Language: Sky Hopinka</h2>
                 <p class="card-text event-organizer">EMPAC</p>
                 <button type="button" class="btns event-category other" style="width: auto;" disabled>Other</button>
                 <br>
@@ -326,7 +326,7 @@
                 alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">MON, 26 APR, 9-10:00 AM EDT</p>
-                <h5 class="card-title event-name">Mental Health Mondays</h5>
+                <h2 class="card-title event-name">Mental Health Mondays</h2>
                 <p class="card-text event-organizer">Rensselaer Union</p>
                 <button type="button" class="btns event-category casual" style="width: auto;" disabled>Casual</button>
                 <br>
@@ -350,7 +350,7 @@
             <img src="../../assets/Yoga-pana.svg" class="card-img-top" alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">MON, 26 APR, 9-10:00 AM EDT</p>
-                <h5 class="card-title event-name">Virtual Fitness Class: Cardio & Core</h5>
+                <h2 class="card-title event-name">Virtual Fitness Class: Cardio & Core</h2>
                 <p class="card-text event-organizer">Mueller Center</p>
                 <button type="button" class="btns event-category workshop" style="width: auto;"
                     disabled>Workshop</button>
@@ -376,7 +376,7 @@
                 alt="Illustration of two people hanging out.">
             <div class="card-body">
                 <p class="card-text event-date">WED, 28 APR, 4-5:00 PM EDT</p>
-                <h5 class="card-title event-name">Tactical Embodiment: Visiting Artist Lecture with Angela Washko</h5>
+                <h2 class="card-title event-name">Tactical Embodiment: Visiting Artist Lecture with Angela Washko</h2>
                 <p class="card-text event-organizer">Ben Chang, HASS Department</p>
                 <button type="button" class="btns event-category workshop" style="width: auto;"
                     disabled>Workshop</button>

--- a/campfire/src/app/home/home.component.html
+++ b/campfire/src/app/home/home.component.html
@@ -4,7 +4,7 @@
     <!-- two columns to position image and text -->
     <div class="row">
         <div class="column1">
-            <img class="peopleMeeting" src="../../assets/peopleMeeting.svg" width="80%">
+            <img class="peopleMeeting" src="../../assets/peopleMeeting.svg" width="80%" alt="An illustration of a group of friends chatting by a fireplace.">
         </div>
         <div class="column2">
             <h2 id="heading"> campfire </h2>
@@ -32,5 +32,5 @@
                 new skill!</p>
         </div>
     </div>
-
 </div>
+<div class="navbar bottom d-flex justify-content-center">All illustrations by Freepik Storyset</div>

--- a/campfire/src/app/join-event/join-event.component.css
+++ b/campfire/src/app/join-event/join-event.component.css
@@ -15,7 +15,7 @@
     display: block;
     margin-top: 10%;
   }
-  h4 {
+  h3 {
     margin-top: 15%;
     font-size: 18px;
   }
@@ -51,7 +51,7 @@
     display: block;
     margin-top: 15%;
   }
-  h4 {
+  h3 {
     margin-top: 15%;
     font-size: 18px;
   }

--- a/campfire/src/app/join-event/join-event.component.html
+++ b/campfire/src/app/join-event/join-event.component.html
@@ -3,95 +3,95 @@
     <form>
         <h2 class="form-title">Join Event</h2>
         <div class="form-group">
-            <label for="emailAddress">Event Code:</label>
-            <input type="email" class="form-control" id="code" aria-describedby="enterCode"
+            <label for="joinEventCode" id="eventCodeHelp">Event Code:</label>
+            <input type="text" class="form-control" id="joinEventCode"  name="joinEventCode" aria-describedby="eventCodeHelp"
                 placeholder="Enter event code">
 
-            <a type="button" class="bg-add btn-add" routerLink="/viewerDashboard">Join Event </a>
+            <a type="button" class="bg-add btn-add" id="joinEventViewButton" routerLink="/viewerDashboard">Join Event </a>
 
         </div>
-        <h4>Just browsing? Select the categories that interest you, and we'll find events that match!</h4>
-        <a type="button" class="bg-add btn-add" routerLink='/eventFeed'>View All Events</a>
+        <h3>Just browsing? Select the categories that interest you, and we'll find events that match!</h3>
+        <a type="button" class="bg-add btn-add"  id="publicFeedButton" routerLink='/eventFeed'>View All Events</a>
         <br>
         <br>
-        <label id="eventCategories">Event Categories:</label>
-        <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="eventCategories">
+        <label for="eventCategories">Event Categories:</label>
+        <div class="btn-group-toggle categories" data-toggle="buttons" id="eventCategories">
             <!--<label class="btn btn-orange">
                 <input type="radio" name="options" id="option1" checked> General Body Meeting (GBM)
             </label>-->
-             <label for="gbm" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
-              <input id="gbm" type="radio" class="btns btn-orange" autocomplete="off"> General Body Meeting (GBM)
+             <label for="gbmButton" id="gbm" class="btn btn-secondary btns btn-orange btn-category">
+              <input id="gbmButton" type="radio" class="btns btn-orange" autocomplete="off"> General Body Meeting (GBM)
             </label>
-            <label for="casual" id="casual" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="casual" type="radio" class="btns btn-orange btn-category" autocomplete="off"> Casual
+            <label for="casualButton" id="casual" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="casualButton" type="radio" class="btns btn-orange btn-category" autocomplete="off"> Casual
             </label>
-            <label for="movie" id="movie" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="movie" type="radio" class="btns btn-orange" autocomplete="off"> Movie Showing
+            <label for="movieButton" id="movie" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="movieButton" type="radio" class="btns btn-orange" autocomplete="off"> Movie Showing
             </label>
-            <label for="games" id="games" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="games" type="radio" class="btns btn-orange" autocomplete="off"> Games/Trivia
+            <label for="gamesButton" id="games" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="gamesButton" type="radio" class="btns btn-orange" autocomplete="off"> Games/Trivia
             </label>
-            <label for="info" id="info" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="info" type="radio" class="btns btn-orange" autocomplete="off"> Informational
+            <label for="infoButton" id="info" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="infoButton" type="radio" class="btns btn-orange" autocomplete="off"> Informational
             </label>
-            <label for="excursion" id="excursion" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="excursion" type="radio" class="btns btn-orange" autocomplete="off"> Excursion
+            <label for="excursionButton" id="excursion" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="excursionButton" type="radio" class="btns btn-orange" autocomplete="off"> Excursion
             </label>
-            <label for="elections" id="elections" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="elections" type="radio" class="btns btn-orange" autocomplete="off"> Elections
+            <label for="electionsButton" id="elections" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="electionsButton" type="radio" class="btns btn-orange" autocomplete="off"> Elections
             </label>
-            <label for="workshop" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="workshop" type="radio" class="btns btn-orange" autocomplete="off"> Workshop
+            <label for="workshopButton" id="workshop" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="workshopButton" type="radio" class="btns btn-orange" autocomplete="off"> Workshop
             </label>
-            <label for="recruit" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="recruit" type="radio" class="btns btn-orange" autocomplete="off"> Recruiting (Company)
+            <label for="recruitButton" id="recruit" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="recruitButton" type="radio" class="btns btn-orange" autocomplete="off"> Recruiting (Company)
             </label>
-            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="other" type="radio" class="btns btn-orange" autocomplete="off"> Other
-            </label>
-        </div>
-        <br>
-        <label id="clubCategories">Club/Organization Categories:</label>
-        <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="clubCategories">
-            <label for="academicProf" id="academicProf" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="academicProf" type="radio" class="btns btn-orange" autocomplete="off"> Academic & Professional
-            </label>
-            <label for="identity" id="identity" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="identity" type="radio" class="btns btn-orange" autocomplete="off"> Identity Based
-            </label>
-            <label for="hobby" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="hobby" type="radio" class="btns btn-orange" autocomplete="off"> Hobby & Special Interest
-            </label>
-            <label for="service" id="service" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="service" type="radio" class="btns btn-orange" autocomplete="off"> Community Service
-            </label>
-            <label for="greek" id="greek" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="greek" type="radio" class="btns btn-orange" autocomplete="off"> Greek Organization
-            </label>
-            <label for="sportsRec " id="sportsRec" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="sportsRec" type="radio" class="btns btn-orange" autocomplete="off"> Sports & Recreation
-            </label>
-            <label for="stuGov" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="stuGov" type="radio" class="btns btn-orange" autocomplete="off"> Student Government & Event Planning
-            </label>
-            <label for="other" id="other" class="btn btn-secondary btns btn-orange btn-category">
-                <input id="other" type="radio" class="btns btn-orange" autocomplete="off"> Other
+            <label for="otherEventButton" id="otherEvent" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="otherEventButton" type="radio" class="btns btn-orange" autocomplete="off"> Other
             </label>
         </div>
         <br>
-        <label id="onlineOffline">Online or Offline:</label>
-        <div class="btn-group-toggle categories" data-toggle="buttons" aria-labelledby="onlineOffline">
-            <label for="online" id="online" class="btn btn-secondary btns btn-orange btn-category">
+        <label for="clubCategories">Club/Organization Categories:</label>
+        <div class="btn-group-toggle categories" data-toggle="buttons" id="clubCategories">
+            <label for="academicProfButton" id="academicProf" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="academicProfButton" type="radio" class="btns btn-orange" autocomplete="off"> Academic & Professional
+            </label>
+            <label for="identityButton" id="identity" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="identityButton" type="radio" class="btns btn-orange" autocomplete="off"> Identity Based
+            </label>
+            <label for="hobbyButton" id="hobby" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="hobbyButton" type="radio" class="btns btn-orange" autocomplete="off"> Hobby & Special Interest
+            </label>
+            <label for="serviceButton" id="service" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="serviceButton" type="radio" class="btns btn-orange" autocomplete="off"> Community Service
+            </label>
+            <label for="greekButton" id="greek" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="greekButton" type="radio" class="btns btn-orange" autocomplete="off"> Greek Organization
+            </label>
+            <label for="sportsRecButton" id="sportsRec" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="sportsRecButton" type="radio" class="btns btn-orange" autocomplete="off"> Sports & Recreation
+            </label>
+            <label for="stuGovButton" id="stuGov" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="stuGovButton" type="radio" class="btns btn-orange" autocomplete="off"> Student Government & Event Planning
+            </label>
+            <label for="otherClubButton" id="otherClub" class="btn btn-secondary btns btn-orange btn-category">
+                <input id="otherClubButton" type="radio" class="btns btn-orange" autocomplete="off"> Other
+            </label>
+        </div>
+        <br>
+        <label for="onlineOffline">Online or Offline:</label>
+        <div class="btn-group-toggle categories" data-toggle="buttons" id="onlineOffline">
+            <label for="online" id="onlineHelp" class="btn btn-secondary btns btn-orange btn-category">
                 <input id="online" type="radio" class="btns btn-orange" autocomplete="off"> Online
             </label>
 
-            <label for="offline" id="offline" class="btn btn-secondary btns btn-orange btn-category">
+            <label for="offline" id="offlineHelp" class="btn btn-secondary btns btn-orange btn-category">
                 <input id="offline" type="radio" class="btns btn-orange" autocomplete="off"> Offline
             </label>
         </div>
         <br>
 
-        <a type="button" class="bg-add btn-add" routerLink="/viewerDashboard">Find Events</a>
+        <a type="button" class="bg-add btn-add" id="findEventsButton" routerLink="/eventFeed">Find Events</a>
 
     </form>
 </div>

--- a/campfire/src/styles.css
+++ b/campfire/src/styles.css
@@ -902,7 +902,7 @@ div.right-align {
     border-color: var(--carnelian); 
 }
 
-#gbm.active, #academicProf.active, .gbm, .academicProf, .gbm-outline:hover, .academicProf-outline:hover{
+#gbm.active, #academicProf.active, #gbm.current, #academicProf.current, .gbm, .academicProf, .gbm-outline:hover, .academicProf-outline:hover{
     background-color: var(--carnelian) !important;
     border-color: var(--carnelian) !important;
     color: white;
@@ -919,7 +919,7 @@ p.gbm-outline, p.academicProf-outline, p.gbm-outline:hover, p.academicProf-outli
     color: var(--cinnabar);
     border-color: var(--cinnabar);
 }
-#casual.active,  .casual, .casual-outline:hover {
+#casual.active, #casual.current,  .casual, .casual-outline:hover {
     background-color: var(--cinnabar) !important;
     border-color: var(--cinnabar) !important;
     color: white;
@@ -938,7 +938,7 @@ p.casual-outline, p.casual-outline:hover {
     border-color: var(--fulvous);
 }
 
-#movie.active, #identity.active, .movie, .identity, .movie-outline:hover, .identity-outline:hover{
+#movie.active, #identity.active, #movie.current, #identity.current, .movie, .identity, .movie-outline:hover, .identity-outline:hover{
     background-color: var(--fulvous) !important;
     border-color: var(--fulvous) !important;
     color: white;
@@ -954,7 +954,7 @@ p.movie-outline, p.identity-outline, p.movie:hover, p.identity-outline:hover {
     border-color: var(--mango);
 }
 
-#games.active, #hobby.active, .games, .hobby, .games-outline:hover, .hobby-outline:hover{
+#games.active, #hobby.active, #games.current, #hobby.current, .games, .hobby, .games-outline:hover, .hobby-outline:hover{
     background-color: var(--mango) !important;
     border-color: var(--mango) !important;
     color: white;
@@ -970,7 +970,7 @@ p.games-outline, p.hobby-outline, p.games-outline:hover, p.hoby-outline:hover {
     border-color: var(--greenPigment);
 }
 
-#info.active, #service.active, .info, .service, .info-outline:hover, .service-outline:hover{
+#info.active, #service.active, #info.current, #service.current,.info, .service, .info-outline:hover, .service-outline:hover{
     background-color: var(--greenPigment) !important;
     border-color: var(--greenPigment) !important;
     color: white;
@@ -987,7 +987,7 @@ p.info-outline, p.service-outline, p.info-outline:hover, p.service-outline:hover
     border-color: var(--dartmouthGreen);
 }
 
-#excursion.active, #greek.active, .excursion, .greek, .excursion-outline:hover, .greek-outline:hover {
+#excursion.active, #greek.active, #excursion.current, #greek.current, .excursion, .greek, .excursion-outline:hover, .greek-outline:hover {
     background-color: var(--dartmouthGreen) !important;
     border-color: var(--dartmouthGreen) !important;
     color: white;
@@ -1004,7 +1004,7 @@ p.excursion-outline, p.greek-outline, p.excursion-outline:hover, p.greek-outline
     border-color: var(--maximumBlue);
 }
 
-#elections.active, #sportsRec.active, .elections, .sportsRec, .elections-outline:hover, .sportsRec-outline:hover {
+#elections.active, #sportsRec.active, #elections.current, #sportsRec.current, .elections, .sportsRec, .elections-outline:hover, .sportsRec-outline:hover {
     background-color: var(--maximumBlue) !important;
     border-color: var(--maximumBlue) !important;
     color: white;
@@ -1020,7 +1020,7 @@ p.elections-outline, p.sportsRec-outline, p.elections-outline:hover, p.sportsRec
     border-color: var(--denim);
 }
 
-#workshop.active, #stuGov.active, .workshop, .stuGov, .workshop-outline:hover, .stuGov-outline:hover {
+#workshop.active, #stuGov.active, #workshop.current, #stuGov.current,  .workshop, .stuGov, .workshop-outline:hover, .stuGov-outline:hover {
     background-color: var(--denim) !important;
     border-color: var(--denim) !important;
     color: white;
@@ -1038,7 +1038,7 @@ p.workshop-outline, p.stuGov-outline, p.workshop-outline:hover, p.stuGov-outline
     border-color: var(--jazzberryJam);
 }
 
-#recruit.active, .recruit, .recruit-outline:hover{
+#recruit.active, #recruit.current, .recruit, .recruit-outline:hover{
     background-color: var(--jazzberryJam) !important;
     border-color: var(--jazzberryJam) !important;
     color: white;
@@ -1050,12 +1050,12 @@ p.recruit-outline, p.recruit-outline:hover {
     font-size: large;
 }
 
-#other, .other-outline {
+#other, #otherClub, #otherEvent, .other-outline {
     color: var(--trypanBlue);
     border-color: var(--trypanBlue);
 }
 
-#other.active, .other, .other-outline:hover{
+#other.active, #otherClub.active, #otherEvent.active, #otherClub.current, #otherEvent.current, .other, .other-outline:hover{
     background-color: var(--trypanBlue) !important;
     border-color: var(--trypanBlue) !important;
     color: white;


### PR DESCRIPTION
- Markup and CSS changes to pass all automatic checks except for color contrast & markup for iframe elements (some of which can't be edited directly on our end, depends on the source's use of semantic markup, like Google)
- Added back image attribution because I think a previous merge removed it
- Added .current class to mark current club and event category on viewer dashboard, fixed club and event categories on viewer dashboard so that they're disabled